### PR TITLE
Fix flag initialization and update credentials loading

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -5,9 +5,8 @@ import deepl_api
 import json
 
 
-f = open('src/creidentials.json')
-cred = json.load(f)
-cred['telegram_api'][0]['api_id']
+with open('src/creidentials.json') as f:
+    cred = json.load(f)
 
 api_id = cred['telegram_api'][0]['api_id']
 api_hash = cred['telegram_api'][0]['api_hash']
@@ -52,11 +51,13 @@ async def my_event_handler(event):
     msg = f'Sent from {user}: \n {text}'
     for user_output_channel in user_output_channels:
 
+        flag = ''
         if user in pro_ru:
             flag = '🇷🇺'
         elif user in pro_ua:
             flag = '🇺🇦'
-        msg = 'Pro' + flag + ' ' + msg
+        if flag:
+            msg = 'Pro' + flag + ' ' + msg
 
         if event.photo:
             await client.send_file(


### PR DESCRIPTION
## Summary
- avoid undefined `flag` by setting a default value and only prepending the message when needed
- read credentials using a context manager and drop stray expression

## Testing
- `python -m py_compile src/run.py`
- `python -m unittest discover`