### PR TITLE
Address issues in credentials path, flag handling, docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,16 @@ python -m venv .venv
 
 source .venv/bin/activate
 
-pip install --use-deprecated=legacy-resolver -Ur requirements.txt
+pip install -r requirements.txt
+
+Create a `src/credentials.json` file with your Telegram API credentials and
+DeepL API key in the following format:
+
+```json
+{
+  "telegram_api": [
+    {"api_id": "<API_ID>", "api_hash": "<API_HASH>"}
+  ],
+  "deepl_api_key": "<DEEPL_KEY>"
+}
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 telethon
 deepl_api
+pytest

--- a/src/run.py
+++ b/src/run.py
@@ -1,13 +1,12 @@
 from telethon import TelegramClient, events
 from telethon.errors import SessionPasswordNeededError
-import  os
+import os
 import deepl_api
 import json
 
 
-f = open('src/creidentials.json')
-cred = json.load(f)
-cred['telegram_api'][0]['api_id']
+with open('src/credentials.json') as f:
+    cred = json.load(f)
 
 api_id = cred['telegram_api'][0]['api_id']
 api_hash = cred['telegram_api'][0]['api_hash']
@@ -32,6 +31,15 @@ user_output_channels = [
     'https://t.me/krntrbsltbt'
 ]
 
+
+def get_flag(username: str) -> str:
+    """Return flag emoji based on the sender username."""
+    if username in pro_ru:
+        return '🇷🇺'
+    if username in pro_ua:
+        return '🇺🇦'
+    return '🏳️'
+
 client = TelegramClient(None, api_id, api_hash)
 
 deepl = deepl_api.DeepL("")
@@ -50,13 +58,9 @@ async def my_event_handler(event):
     )
     text = translations[0]['text']
     msg = f'Sent from {user}: \n {text}'
+    flag = get_flag(user)
+    msg = 'Pro' + flag + ' ' + msg
     for user_output_channel in user_output_channels:
-
-        if user in pro_ru:
-            flag = '🇷🇺'
-        elif user in pro_ua:
-            flag = '🇺🇦'
-        msg = 'Pro' + flag + ' ' + msg
 
         if event.photo:
             await client.send_file(

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,16 @@
+import pytest
+from src.run import get_flag
+
+
+def test_flag_known_russian():
+    assert get_flag('grey_zone') == '🇷🇺'
+
+
+def test_flag_known_ukrainian():
+    assert get_flag('ukraina_novosti') == '🇺🇦'
+
+
+def test_flag_unknown_user():
+    # Should return neutral flag and not raise any errors
+    assert get_flag('some_unknown_user') == '🏳️'
+


### PR DESCRIPTION
## Summary
- fix typo when loading credentials file
- add `get_flag` helper and initialize flag for unknown senders
- document required `credentials.json` in README and update pip command
- clean up `requirements.txt` and add pytest dependency
- introduce pytest suite for flag logic

## Testing
- `pytest -q` *(fails: No module named pytest)*